### PR TITLE
[chore] move google analytics to partytown

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -37,7 +37,7 @@ const nextConfig = {
     return config;
   },
   reactStrictMode: true,
-  experimental: { esmExternals: true },
+  experimental: { esmExternals: true, nextScriptWorkers: true },
   pageExtensions: ['ts', 'tsx', 'md', 'mdx'],
   images: {
     domains: ['res.cloudinary.com'],

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "postbuild": "next-sitemap --config next-sitemap.config.mjs"
     },
     "dependencies": {
+        "@builder.io/partytown": "^0.7.5",
         "@chakra-ui/react": "^2.4.9",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -30,19 +30,25 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ChakraProvider theme={theme} resetCSS>
       <Script
-        async
+        strategy="worker"
         src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_TRACKING_ID}`}
       />
-      <Script id="google-analytics">
-        {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){window.dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', '${process.env.NEXT_PUBLIC_GA_TRACKING_ID}', {
-            page_path: window.location.pathname,
-          });
-        `}
-      </Script>
+      <Script
+        id="partytown-google-analytics"
+        type="text/partytown"
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            window.gtag = function gtag(){window.dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', '${process.env.NEXT_PUBLIC_GA_TRACKING_ID}', { 
+                page_path: window.location.pathname,
+            });
+        `,
+        }}
+      />
+
       <Head>
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,7 +5,19 @@ export default class Document extends NextDocument {
   render() {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <script
+            data-partytown-config
+            dangerouslySetInnerHTML={{
+              __html: `
+                    partytown = {
+                        lib: "/_next/static/~partytown/",
+                        forward: ["gtag"]           
+                    };
+                `,
+            }}
+          />
+        </Head>
         <body>
           <ColorModeScript initialColorMode={'dark'} />
           <Main />

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,6 +58,11 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
+"@builder.io/partytown@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@builder.io/partytown/-/partytown-0.7.5.tgz#f501e3db37a5ac659f21ba0c2e61b278e58b64b9"
+  integrity sha512-Zbr2Eo0AQ4yzmQr/36/h+6LKjmdVBB3Q5cGzO6rtlIKB/IOpbQVUZW+XAnhpJmJr9sIF97OZjgbhG9k7Sjn4yw==
+
 "@chakra-ui/accordion@2.1.9":
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-2.1.9.tgz#20fa86d94dc034251df2f7c8595ae4dd541a29d9"


### PR DESCRIPTION
Attempting to move Google Analytics to PartyTown to help load speed.

Based on https://dev.to/valse/how-to-add-google-analytics-gtag-to-nextjs-using-partytown-bn4